### PR TITLE
Steam save images to database

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { serial, mysqlTable, text, varchar, int } from "drizzle-orm/mysql-core";
+import { serial, mysqlTable, text, varchar, int, varbinary, mediumtext } from "drizzle-orm/mysql-core";
 import {
   createSelectSchema,
   createInsertSchema,
@@ -17,9 +17,11 @@ export const gamesTable = mysqlTable("games", {
   gameID: varchar('game_id', { length: 255 }).unique().notNull(),
   name: varchar('name', { length: 255 }).notNull(),
   description: text().notNull(),
-  icon: varchar('icon', { length: 255 }).notNull(),
-  headerImage: varchar('header_image', { length: 255 }).notNull(),
-  bannerImage: varchar('banner_image', { length: 255 }).notNull(),
+  icon: mediumtext('icon'),
+  logo: mediumtext('logo'),
+  headerImage: mediumtext('headerImage'),
+  imageCard: mediumtext('imageCard'),
+  heroImage: mediumtext('heroImage'),
   type: varchar('type', { length: 255 }).notNull(),
 });
 

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { serial, mysqlTable, text, varchar, int, varbinary, mediumtext } from "drizzle-orm/mysql-core";
+import { serial, mysqlTable, text, varchar, int, mediumtext } from "drizzle-orm/mysql-core";
 import {
   createSelectSchema,
   createInsertSchema,


### PR DESCRIPTION
This pull request includes several important changes to the `SteamModel` class and the database schema for the `games` table. The changes aim to enhance the handling of game data and images, as well as update the database schema to accommodate new image fields.

Improvements to `SteamModel` class:

* Replaced `#getSteamGameData` and `#getSteamGameIcon` methods with `#getGameData` and `#getIcon`, respectively, and updated their usages in the `create` method to fetch game data and icons.
* Introduced a new private method `#getAllImages` to fetch multiple images (logo, header, library hero, library 600x900) for a game and updated the `create` method to use this new method.
* Added a new private method `#getImageAsBase64` to fetch images as base64-encoded strings, which is used by the `#getIcon` and `#getAllImages` methods.

Updates to database schema:

* Added `mediumtext` type to `drizzle-orm/mysql-core` imports to support larger text fields for images.
* Modified the `games` table schema to replace `icon`, `headerImage`, and `bannerImage` fields with `mediumtext` fields for `icon`, `logo`, `headerImage`, `imageCard`, and `heroImage`.